### PR TITLE
Update DISCOVER: 2023 Learning Journeys

### DIFF
--- a/_infocomm-media-clubs-cca/DISCOVER: Out Of Classroom Exp/DISCOVER: 2023 Learning Journeys.md
+++ b/_infocomm-media-clubs-cca/DISCOVER: Out Of Classroom Exp/DISCOVER: 2023 Learning Journeys.md
@@ -97,7 +97,7 @@ Experience The Gym’s holistic production studio and hands-on with eSports cast
 
 **<u>Learning Journey Details</u>** <br>
 **Time:** 3pm to 5pm<br>
-**Dates:** (Fully Booked)<br>
+**Dates:** July - 31 <br>
 **Open to:** Secondary and JC Students <br>
 **Capacity:** 20 students per school for each session<br>
 **Location:** 316 Jalan Besar, Singapore 208974

--- a/_infocomm-media-clubs-cca/DISCOVER: Out Of Classroom Exp/DISCOVER: 2023 Learning Journeys.md
+++ b/_infocomm-media-clubs-cca/DISCOVER: Out Of Classroom Exp/DISCOVER: 2023 Learning Journeys.md
@@ -48,7 +48,7 @@ Dive into a wonderland where anything is possible. From thrilling roller coaster
 **<u>Learning Journey Details</u>** <br>
 **Time:** 3:30pm to 5:30pm<br>
 **Dates:** 
-* July - 17 &amp; 27 
+* July - 31 
 * August - 3, 16 &amp; 31
 * October - 11, 12, 18, 19 &amp; 25 <br>
 
@@ -111,7 +111,7 @@ Make your voice be heard and let your creative minds curate captivating shareabl
 
 **<u>Learning Journey Details</u>**<br>
 **Time:** 3pm to 5pm<br>
-**Dates:**  October - 11 &amp; 25 <br>
+**Dates:** (Fully Booked) <br>
 **Open to:** Secondary and JC students<br>
 **Capacity:** 20 students per school for each session <br>
 **Location:** Chutex Building, 219 Kallang Bahru, #04-00 Chutex Building, Singapore 339348
@@ -139,7 +139,7 @@ From National Day Parade to New Year’s Eve Party, swarm of drones are being us
 
 **<u>Learning Journey Details</u>** <br>
 **Time:** 3pm to 5pm<br>
-**Dates:** August - 11<br>
+**Dates:** (Fully Booked)<br>
 **Open to:** Primary / Secondary and JC students <br>
 **Capacity:** 20 students per school for each session
 <br>


### PR DESCRIPTION
Hi Quanhan,

Pull request submitted to update the available dates for DISCOVER 2023 Learning Journeys.

**1) Headrock VR**
Current
July - 17 & 27
August - 3, 16 & 31
October - 11, 12, 18, 19 & 25

After Update
July - 31
August - 3, 16 & 31
October - 11, 12, 18, 19 & 25

**2) TSL**
Current
October - 11 & 25

After Update
(Fully Booked)

**3) 65Drones**
Current
August – 11

After Update
(Fully Booked)


Regards,

Winson